### PR TITLE
Fix: theme toggle icon rendering issue #7

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -1,9 +1,18 @@
 "use client"
 
 import { ThemeProvider } from "next-themes"
+import { useEffect, useState } from "react"
 import { RecoilRoot } from "recoil"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
+  const [isMount, setMount] = useState(false)
+
+  useEffect(() => {
+    setMount(true)
+  }, [])
+
+  if (!isMount) return null
+
   return (
     <ThemeProvider attribute="class">
       <RecoilRoot>{children}</RecoilRoot>

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -100,7 +100,7 @@ export default function SimpleCalendar() {
                 isWeekend(day) && "text-red-600 dark:text-red-500",
                 selectedDates.includes(day) &&
                   "bg-amber-300 text-gray-100 hover:bg-amber-200 dark:bg-blue-600 hover:dark:bg-blue-500",
-                "flex h-9 w-9 items-center justify-center rounded-lg font-semibold"
+                "my-0.5 flex h-9 w-9 items-center justify-center rounded-lg font-semibold"
               )}
             >
               <time dateTime={format(day, "yyyy-MM-dd")}>

--- a/app/ui/ThemeToggle.tsx
+++ b/app/ui/ThemeToggle.tsx
@@ -1,14 +1,19 @@
 "use client"
 
+import { FaceSmileIcon } from "@heroicons/react/16/solid"
 import { SunIcon, MoonIcon } from "@heroicons/react/24/outline"
 import { useTheme } from "next-themes"
 
 function ToggleIcon() {
-  const { theme, setTheme } = useTheme()
+  const { systemTheme, theme, setTheme } = useTheme()
+
+  const currentTheme = theme === "system" ? systemTheme : theme
 
   return (
-    <button onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
-      {theme === "dark" ? (
+    <button
+      onClick={() => setTheme(currentTheme === "dark" ? "light" : "dark")}
+    >
+      {currentTheme === "dark" ? (
         <MoonIcon className="h-6 w-6 hover:cursor-pointer dark:text-gray-400" />
       ) : (
         <SunIcon className="h-6 w-6 hover:cursor-pointer dark:text-gray-400" />


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
버그 원인: hydration mismatch error (서버와 클라이언트 구조가 다른 에러)
해결 방법: provider 컴포넌트에서 useEffect를 사용하여 마운트 상태를 받아오고, 마운트가 되었을 때 themeprovider를 return하도록 적용


## 📢 Description
서버 측에서 처음 렌더링을 할 때 useTheme의 theme은 서버에서는 알 수 없는 상태이기 때문에 undefined가 되는데, 이후 themeprovider가 렌더링되면 theme의 상태가 존재하게 되므로 서버와 클라이언트의 구조가 달라지게 됩니다. 이를 hydration mismatch error라고 합니다.

themeprovider는 theme을 브라우저 local storage에 저장하고, 또 불러오는데 페이지를 새로고침하면 서버 측에서 렌더링을 다시 하게 되면서 local storage에 저장되어 있는 theme의 값을 가져오려고 합니다. 그러나 서버 측에서는 local storage에 접근할 수 없기 때문에 값을 제대로 가져오지 못하게 됩니다. 따라서 현재 적용된 테마는 다크모드 그대로 유지되어 있지만 theme 값을 제대로 가져오지 못했으므로 적절한 토글 아이콘을 렌더링하지 못하게 됩니다.

이를 방지하기 위해, 컴포넌트가 제대로 마운트 되어 local storage에 접근이 가능할 때까지 기다렸다가 그 이후에 theme 값을 제대로 불러와 적절한 토글 아이콘을 렌더링하도록 하였습니다.


## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat를 연결해주세요!
-->
- #7


<!-- ScreenShot [optional] -->
