### PR TITLE
11 feat add button for selectunselect all dates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@
   }
 
   .checkbox {
-    @apply rounded border-gray-300 bg-gray-50 text-amber-300 focus:ring-2 focus:ring-blue-400 dark:border-gray-600 dark:bg-gray-700 dark:text-blue-600 dark:ring-offset-gray-800 dark:focus:ring-cyan-600;
+    @apply rounded border-gray-300 bg-gray-50 text-amber-300 focus:ring-2 focus:ring-amber-400 dark:border-gray-600 dark:bg-gray-700 dark:text-blue-600 dark:ring-offset-gray-800 dark:focus:ring-cyan-600;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,10 @@
   .unselected-button {
     @apply text-gray-900 hover:bg-gray-300 dark:text-gray-300 hover:dark:bg-gray-500;
   }
+
+  .deselected-button {
+    @apply border bg-white text-gray-900 hover:bg-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300 hover:dark:bg-gray-500;
+  }
 }
 
 @layer utilities {

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .selected-button {
+    @apply bg-amber-300 text-gray-100 hover:bg-amber-200 dark:bg-blue-600 hover:dark:bg-blue-500;
+  }
+
+  .unselected-button {
+    @apply text-gray-900 hover:bg-gray-300 dark:text-gray-300 hover:dark:bg-gray-500;
+  }
+}
+
 @layer utilities {
   .for-mobile {
     -ms-user-select: none;

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,10 @@
   .deselected-button {
     @apply border bg-white text-gray-900 hover:bg-gray-300 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300 hover:dark:bg-gray-500;
   }
+
+  .checkbox {
+    @apply rounded border-gray-300 bg-gray-50 text-amber-300 focus:ring-2 focus:ring-blue-400 dark:border-gray-600 dark:bg-gray-700 dark:text-blue-600 dark:ring-offset-gray-800 dark:focus:ring-cyan-600;
+  }
 }
 
 @layer utilities {

--- a/app/ui/CheckBox.tsx
+++ b/app/ui/CheckBox.tsx
@@ -1,0 +1,33 @@
+interface Props {
+  className?: string
+  id?: string
+  value?: string
+  label?: string
+  checked?: boolean
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export default function CheckBox({
+  className,
+  id,
+  value,
+  label,
+  checked,
+  onChange,
+}: Props) {
+  return (
+    <div className={`flex items-center ${className}`}>
+      <input
+        type="checkbox"
+        id={id}
+        className="checkbox h-4 w-4"
+        value={value}
+        onChange={onChange}
+        checked={checked}
+      />
+      <label htmlFor={id} className="me-1 ms-1 text-sm font-medium">
+        {label}
+      </label>
+    </div>
+  )
+}

--- a/app/ui/CheckBox.tsx
+++ b/app/ui/CheckBox.tsx
@@ -25,7 +25,10 @@ export default function CheckBox({
         onChange={onChange}
         checked={checked}
       />
-      <label htmlFor={id} className="me-1 ms-1 text-sm font-medium">
+      <label
+        htmlFor={id}
+        className="ms-2 select-none text-sm font-medium text-gray-900 dark:text-gray-300"
+      >
         {label}
       </label>
     </div>

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -75,7 +75,7 @@ export default function SimpleCalendar() {
         </button>
         <button
           onClick={() => setSelectedDates([])}
-          className="unselected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg bg-gray-200 dark:bg-gray-700"
+          className="deselected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg"
         >
           모든 날 선택 해제
         </button>

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -6,10 +6,10 @@ import {
   lastDayOfMonthState,
   selectedDatesState,
 } from "@/app/states/days-of-month-state"
+import CheckBox from "@/app/ui/CheckBox"
 import { format, getDay, isSameDay, isWeekend } from "date-fns"
 import { isMobile } from "react-device-detect"
 import { useRecoilState, useRecoilValue } from "recoil"
-import CheckBox from "./CheckBox"
 
 function classNames(...classes: (string | boolean)[]) {
   return classes.filter(Boolean).join(" ")
@@ -74,25 +74,13 @@ export default function SimpleCalendar() {
   }
 
   return (
-    <div>
-      <CheckBox
-        id="all-dates-select"
-        className="justify-end pb-2 pr-2"
-        label="모든 날짜 선택"
-        checked={selectedDates.length === availableDates.length}
-        onChange={() => {
-          if (selectedDates.length === availableDates.length) {
-            setSelectedDates([])
-          } else {
-            setSelectedDates(availableDates)
-          }
-        }}
-      />
-      <div className="for-mobile max-w-sm rounded-lg bg-gray-50 p-3 py-8 shadow-lg dark:bg-gray-700">
+    <>
+      <div className="for-mobile max-w-sm rounded-lg bg-gray-50 px-4 pb-4 pt-6 shadow-lg dark:bg-gray-700">
         <h2 className="flex-auto text-center font-medium text-gray-900 dark:text-white">
-          🗓️ {format(lastDayOfMonth, "M")}월 남은 날 {availableDates.length}일
+          🗓️ {format(lastDayOfMonth, "M")}월, 남은 날 {availableDates.length}일
         </h2>
-        <div className="mt-8 grid grid-cols-7 text-center">
+
+        <div className="mt-4 grid grid-cols-7 text-center">
           {weekDays.map((day, index) => (
             <div
               key={index}
@@ -136,7 +124,20 @@ export default function SimpleCalendar() {
             </div>
           ))}
         </div>
+        <CheckBox
+          id="all-dates-select"
+          className="mr-1 mt-4 flex justify-end"
+          label="모든 날짜 선택"
+          checked={selectedDates.length === availableDates.length}
+          onChange={() => {
+            if (selectedDates.length === availableDates.length) {
+              setSelectedDates([])
+            } else {
+              setSelectedDates(availableDates)
+            }
+          }}
+        />
       </div>
-    </div>
+    </>
   )
 }

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -65,50 +65,65 @@ export default function SimpleCalendar() {
   }
 
   return (
-    <div className="for-mobile max-w-sm rounded-lg bg-gray-50 p-3 py-8 shadow-lg dark:bg-gray-700">
-      <h2 className="flex-auto text-center text-gray-900 dark:text-white">
-        🗓️ {format(lastDayOfMonth, "M")}월 남은 날 {availableDates.length}일
-      </h2>
-      <div className="mt-8 grid grid-cols-7 text-center">
-        {weekDays.map((day, index) => (
-          <div
-            key={index}
-            className="text-sm font-semibold leading-6 text-amber-300 dark:text-blue-400"
-          >
-            {day}
-          </div>
-        ))}
+    <div>
+      <div className="flex justify-center pb-5 text-xs font-semibold">
+        <button
+          onClick={() => setSelectedDates(availableDates)}
+          className="selected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg"
+        >
+          모든 날 선택
+        </button>
+        <button
+          onClick={() => setSelectedDates([])}
+          className="unselected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg bg-gray-200 dark:bg-gray-700"
+        >
+          모든 날 선택 해제
+        </button>
       </div>
-      <div className="mt-2 grid grid-cols-7 text-sm">
-        {days.map((day, dayIdx) => (
-          <div
-            key={day.toString()}
-            className={classNames(
-              dayIdx === 0 && colStartClasses[getDay(day)],
-              "item-center px-0.5 py-0.5"
-            )}
-          >
-            <button
-              disabled={!isAvailableDay(day)}
-              onTouchEnd={() => datePickMobile(day)}
-              onClick={() => datePick(day)}
+      <div className="for-mobile max-w-sm rounded-lg bg-gray-50 p-3 py-8 shadow-lg dark:bg-gray-700">
+        <h2 className="flex-auto text-center text-gray-900 dark:text-white">
+          🗓️ {format(lastDayOfMonth, "M")}월 남은 날 {availableDates.length}일
+        </h2>
+        <div className="mt-8 grid grid-cols-7 text-center">
+          {weekDays.map((day, index) => (
+            <div
+              key={index}
+              className="text-sm font-semibold leading-6 text-amber-300 dark:text-blue-400"
+            >
+              {day}
+            </div>
+          ))}
+        </div>
+        <div className="mt-2 grid grid-cols-7 text-sm">
+          {days.map((day, dayIdx) => (
+            <div
+              key={day.toString()}
               className={classNames(
-                !isAvailableDay(day) && "disabled: cursor-default opacity-30",
-                isAvailableDay(day) &&
-                  !selectedDates.includes(day) &&
-                  "text-gray-900 hover:bg-gray-300 dark:text-gray-300 hover:dark:bg-gray-500",
-                isWeekend(day) && "text-red-500 dark:text-red-500",
-                selectedDates.includes(day) &&
-                  "bg-amber-300 text-gray-100 hover:bg-amber-200 dark:bg-blue-600 hover:dark:bg-blue-500",
-                "flex h-9 w-9 items-center justify-center rounded-lg font-semibold"
+                dayIdx === 0 && colStartClasses[getDay(day)],
+                "item-center px-0.5 py-0.5"
               )}
             >
-              <time dateTime={format(day, "yyyy-MM-dd")}>
-                {format(day, "d")}
-              </time>
-            </button>
-          </div>
-        ))}
+              <button
+                disabled={!isAvailableDay(day)}
+                onTouchEnd={() => datePickMobile(day)}
+                onClick={() => datePick(day)}
+                className={classNames(
+                  !isAvailableDay(day) && "disabled: cursor-default opacity-30",
+                  isAvailableDay(day) &&
+                    !selectedDates.includes(day) &&
+                    "unselected-button",
+                  isWeekend(day) && "text-red-500 dark:text-red-500",
+                  selectedDates.includes(day) && "selected-button",
+                  "flex h-9 w-9 items-center justify-center rounded-lg font-semibold"
+                )}
+              >
+                <time dateTime={format(day, "yyyy-MM-dd")}>
+                  {format(day, "d")}
+                </time>
+              </button>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -78,7 +78,7 @@ export default function SimpleCalendar() {
       <CheckBox
         id="all-dates-select"
         className="justify-end pb-2 pr-2"
-        label="모든 날 선택하기"
+        label="모든 날짜 선택"
         checked={selectedDates.length === availableDates.length}
         onChange={() => {
           if (selectedDates.length === availableDates.length) {

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -32,6 +32,9 @@ export default function SimpleCalendar() {
     "col-start-7",
   ]
 
+  let touchPointX: number = 0
+  let touchPointY: number = 0
+
   const isAvailableDay = (day: Date) => {
     return availableDates.includes(day)
   }
@@ -50,8 +53,13 @@ export default function SimpleCalendar() {
     }
   }
 
-  const datePickMobile = (day: Date) => {
+  const datePickMobile = (day: Date, e: any) => {
     if (!isMobile || !isAvailableDay(day)) return
+    if (
+      touchPointX !== e.changedTouches[0].clientX ||
+      touchPointY !== e.changedTouches[0].clientY
+    )
+      return
     const dates = selectedDates.filter((e) => !isSameDay(e, day))
     const alreadyPickedDate = selectedDates.find((e) => isSameDay(e, day))
     if (alreadyPickedDate) {
@@ -105,7 +113,11 @@ export default function SimpleCalendar() {
             >
               <button
                 disabled={!isAvailableDay(day)}
-                onTouchEnd={() => datePickMobile(day)}
+                onTouchStart={(e) => {
+                  touchPointX = e.touches[0].clientX
+                  touchPointY = e.touches[0].clientY
+                }}
+                onTouchEnd={(e) => datePickMobile(day, e)}
                 onClick={() => datePick(day)}
                 className={classNames(
                   !isAvailableDay(day) && "disabled: cursor-default opacity-30",

--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -9,6 +9,7 @@ import {
 import { format, getDay, isSameDay, isWeekend } from "date-fns"
 import { isMobile } from "react-device-detect"
 import { useRecoilState, useRecoilValue } from "recoil"
+import CheckBox from "./CheckBox"
 
 function classNames(...classes: (string | boolean)[]) {
   return classes.filter(Boolean).join(" ")
@@ -74,22 +75,21 @@ export default function SimpleCalendar() {
 
   return (
     <div>
-      <div className="flex justify-center pb-5 text-xs font-semibold">
-        <button
-          onClick={() => setSelectedDates(availableDates)}
-          className="selected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg"
-        >
-          모든 날 선택
-        </button>
-        <button
-          onClick={() => setSelectedDates([])}
-          className="deselected-button mx-2 flex h-9 w-28 items-center justify-center rounded-lg"
-        >
-          모든 날 선택 해제
-        </button>
-      </div>
+      <CheckBox
+        id="all-dates-select"
+        className="justify-end pb-2 pr-2"
+        label="모든 날 선택하기"
+        checked={selectedDates.length === availableDates.length}
+        onChange={() => {
+          if (selectedDates.length === availableDates.length) {
+            setSelectedDates([])
+          } else {
+            setSelectedDates(availableDates)
+          }
+        }}
+      />
       <div className="for-mobile max-w-sm rounded-lg bg-gray-50 p-3 py-8 shadow-lg dark:bg-gray-700">
-        <h2 className="flex-auto text-center text-gray-900 dark:text-white">
+        <h2 className="flex-auto text-center font-medium text-gray-900 dark:text-white">
           🗓️ {format(lastDayOfMonth, "M")}월 남은 날 {availableDates.length}일
         </h2>
         <div className="mt-8 grid grid-cols-7 text-center">


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->
- 모든 날 선택 / 선택 해제 버튼을 달력 상단에 추가
- 달력 날짜버튼 부분을 스크롤할 때 의도하지 않은 선택 / 선택해제 되지 않도록 변경

## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->
달력에 있는 날짜를 전부 선택하거나, 선택 해제할 수 있도록 버튼 두 개를 상단에 배치했습니다.
처음엔 하단에 만들었으나 달력을 보면서 아래 쪽 계산 결과를 함께 보기 편하도록 상단 배치로 결정했습니다.

또 달력에 있는 날짜 버튼 영역에 손가락을 두고 페이지를 스크롤할 때 의도하지 않게 해당 날짜가 선택되거나 선택 해제되는 현상을 수정했습니다.

## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat를 연결해주세요!
-->
- #11 

<!-- ScreenShot [optional] -->
