### PR TITLE
9 bug page blink when refreshing in dark theme

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -1,12 +1,11 @@
 "use client"
 
 import { ThemeProvider } from "next-themes"
-import { useEffect, useState } from "react"
 import { RecoilRoot } from "recoil"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider attribute="class" enableSystem={true}>
       <RecoilRoot>{children}</RecoilRoot>
     </ThemeProvider>
   )

--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -5,16 +5,8 @@ import { useEffect, useState } from "react"
 import { RecoilRoot } from "recoil"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [isMount, setMount] = useState(false)
-
-  useEffect(() => {
-    setMount(true)
-  }, [])
-
-  if (!isMount) return null
-
   return (
-    <ThemeProvider attribute="class">
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <RecoilRoot>{children}</RecoilRoot>
     </ThemeProvider>
   )

--- a/app/ui/ThemeToggle.tsx
+++ b/app/ui/ThemeToggle.tsx
@@ -1,25 +1,42 @@
 "use client"
 
-import { FaceSmileIcon } from "@heroicons/react/16/solid"
-import { SunIcon, MoonIcon } from "@heroicons/react/24/outline"
+import {
+  SunIcon,
+  MoonIcon,
+  StarIcon,
+  ArrowPathIcon,
+} from "@heroicons/react/24/outline"
 import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
 
 function ToggleIcon() {
-  const { systemTheme, theme, setTheme } = useTheme()
+  const { resolvedTheme, setTheme } = useTheme()
+  const [isMount, setMount] = useState(false)
 
-  const currentTheme = theme === "system" ? systemTheme : theme
+  useEffect(() => {
+    setMount(true)
+  }, [])
 
-  return (
-    <button
-      onClick={() => setTheme(currentTheme === "dark" ? "light" : "dark")}
-    >
-      {currentTheme === "dark" ? (
-        <MoonIcon className="h-6 w-6 hover:cursor-pointer dark:text-gray-400" />
-      ) : (
-        <SunIcon className="h-6 w-6 hover:cursor-pointer dark:text-gray-400" />
-      )}
-    </button>
-  )
+  if (!isMount)
+    return (
+      <ArrowPathIcon className="h-6 w-6 hover:cursor-pointer dark:text-gray-400" />
+    )
+
+  if (resolvedTheme === "dark") {
+    return (
+      <MoonIcon
+        onClick={() => setTheme("light")}
+        className="h-6 w-6 hover:cursor-pointer dark:text-gray-400"
+      />
+    )
+  } else {
+    return (
+      <SunIcon
+        onClick={() => setTheme("dark")}
+        className="h-6 w-6 hover:cursor-pointer dark:text-gray-400"
+      />
+    )
+  }
 }
 
 export default function ThemeToggle() {

--- a/app/ui/ThemeToggle.tsx
+++ b/app/ui/ThemeToggle.tsx
@@ -1,11 +1,6 @@
 "use client"
 
-import {
-  SunIcon,
-  MoonIcon,
-  StarIcon,
-  ArrowPathIcon,
-} from "@heroicons/react/24/outline"
+import { SunIcon, MoonIcon, ArrowPathIcon } from "@heroicons/react/24/outline"
 import { useTheme } from "next-themes"
 import { useEffect, useState } from "react"
 


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->
다크모드일때 페이지를 새로고침하면 하얗게 깜빡이는 문제를 수정했습니다.


## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->
기존에는 provider 자체에서 마운트 확인 후 리턴하는 로직을 가지고 있었습니다.
그러면 새로고침을 할 때마다 서버에서 전체 페이지를 다시 렌더링하고, 그 짧은 시간동안 브라우저는 현재 적용된 theme이 무엇인지 알 수 없기 때문에 기본 흰 색 페이지를 보여줍니다. 그 후 서버로부터 html을 넘겨받으면 그때서야 다크모드 페이지를 보여줬습니다. 이때문에 하얗게 깜빡이는 것 같은 현상이 발생한 것입니다.

hydration mismatch error 방지를 위해 마운트 확인 후 컴포넌트를 리턴하는 로직을 만든건데, 어차피 theme 값에 따라 렌더링이 달라지는 부분은 ThemeToggle 아이콘 뿐이므로 해당 컴포넌트 영역에서만 마운트 확인을 하는 것으로 변경하였습니다. 이렇게 되면 아이콘만 다시 렌더링하므로 기존 다크모드 페이지는 흰 색으로 깜빡이지 않습니다.
다만 마운트가 제대로 되기 전까지 theme 값을 알 수 없는 것은 여전히 동일하므로 그 동안 loading 아이콘을 보여주도록 코드를 추가했습니다.


## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat를 연결해주세요!
-->
- #9

<!-- ScreenShot [optional] -->
