### PR TITLE
Fix: disable touch action when user scrolling the page

### DIFF
--- a/app/ui/SimpleCalendar.tsx
+++ b/app/ui/SimpleCalendar.tsx
@@ -33,8 +33,7 @@ export default function SimpleCalendar() {
     "col-start-7",
   ]
 
-  //let touchPointX: number = 0
-  //let touchPointY: number = 0
+  let isTouchMove: boolean = false
 
   const isAvailableDay = (day: Date) => {
     return availableDates.includes(day)
@@ -56,11 +55,10 @@ export default function SimpleCalendar() {
 
   const datePickMobile = (day: Date, e: any) => {
     if (!isMobile || !isAvailableDay(day)) return
-    //if (
-    //  touchPointX !== e.changedTouches[0].clientX ||
-    //  touchPointY !== e.changedTouches[0].clientY
-    //)
-    //  return
+    if (isTouchMove) {
+      isTouchMove = false
+      return
+    }
     const dates = selectedDates.filter((e) => !isSameDay(e, day))
     const alreadyPickedDate = selectedDates.find((e) => isSameDay(e, day))
     if (alreadyPickedDate) {
@@ -101,11 +99,9 @@ export default function SimpleCalendar() {
             >
               <button
                 disabled={!isAvailableDay(day)}
-                //onTouchStart={(e) => {
-                //  touchPointX = e.touches[0].clientX
-                //  touchPointY = e.touches[0].clientY
-                //}}
+                onTouchMove={() => (isTouchMove = true)}
                 onTouchEnd={(e) => datePickMobile(day, e)}
+                onScroll={() => alert("scrolled!")}
                 onClick={() => datePick(day)}
                 className={classNames(
                   !isAvailableDay(day) && "disabled: cursor-default opacity-30",


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->

touch event 중에서 touchMove가 발생할 경우 날짜 버튼 클릭 동작을 하지 않도록 코드를 변경하여
스크롤은 정상적으로 가능하지만 의도하지 않은 날짜 선택이 발생하지 않음


## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->

기존에는 touchStart를 한 좌표와 touchEnd시의 좌표를 비교하여 조금이라도 좌표가 달라질 경우 버튼 동작을 제한했었습니다.
이번에는 touchMove를 따로 감지하여서, 페이지 스크롤이 되는 경우에만 버튼이 동작하지 않도록 하였습니다.


## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat를 연결해주세요!
-->
- #14 


<!-- ScreenShot [optional] -->
